### PR TITLE
Configure meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,9 +31,9 @@ fc_id = fc.get_id()
 lib_deps = []
 
 if get_option('openmp')
-  omp_dep = dependency('openmp', required: fc_id != 'intel' and fc_id != 'nvidia_hpc')
+  omp_dep = dependency('openmp', required: fc_id != 'intel' and fc_id != 'intel-llvm' and fc_id != 'nvidia_hpc')
   if not omp_dep.found()
-    if fc_id == 'intel'
+    if fc_id == 'intel' or fc_id != 'intel-llvm'
       message('Using -qopenmp to use OpenMP with Intel compilers')
       omp_dep = declare_dependency(
         compile_args: '-qopenmp',

--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,33 @@ project(
   ],
 )
 
+fc = meson.get_compiler('fortran')
+fc_id = fc.get_id()
+
 lib_deps = []
+
+if get_option('openmp')
+  omp_dep = dependency('openmp', required: fc_id != 'intel' and fc_id != 'nvidia_hpc')
+  if not omp_dep.found()
+    if fc_id == 'intel'
+      message('Using -qopenmp to use OpenMP with Intel compilers')
+      omp_dep = declare_dependency(
+        compile_args: '-qopenmp',
+        link_args: '-qopenmp',
+      )
+    else
+      message('Using -mp to use OpenMP with NVHPC compilers')
+      omp_dep = declare_dependency(
+        compile_args: '-mp',
+        link_args: '-mp',
+      )
+    endif
+  endif
+  lib_deps += omp_dep
+endif
+
+lib_deps += dependency('threads')
+
 subdir('config')
 
 srcs = []


### PR DESCRIPTION
* Make OpenMP dependency explicit, so that symbols can be found during build.
* Define Fortran compiler. `fc_id` was previously used, but never set.

The specification for the OpenMP dependency follows the form used in the [meson.build for xtb](https://github.com/grimme-lab/xtb/blob/main/meson/meson.build#L167). The change here was sufficient for me to be able to compile with ifort 2022.0.2 (or ifx 2024.0).