### PR TITLE
Include custom lapack backend as an option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,7 +3,7 @@ option(
   type: 'combo',
   value: 'auto',
   yield: true,
-  choices: ['auto', 'mkl', 'mkl-rt', 'openblas', 'netlib'],
+  choices: ['auto', 'mkl', 'mkl-rt', 'openblas', 'netlib', 'custom'],
   description : 'linear algebra backend',
 )
 


### PR DESCRIPTION
Partial support for a custom lapack backend was added in 814b2e4d536e71760d12409610eefdc38d575aa2, but the commit didn't extend the list of available options.