### PR TITLE
Allow detection of TOML-F

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -112,12 +112,10 @@ numsa_dep = dependency(
 lib_deps += numsa_dep
 
 
-tomlf_prj = subproject(
+tomlf_dep = dependency(
   'toml-f',
-  version: '>=0.2',
-  default_options: [
-    'default_library=static',
-  ],
+  version: '>=0.2.0',
+  fallback: ['toml-f', 'tomlf_dep'],
+  default_options: ['default_library=static'],
 )
-tomlf_dep = tomlf_prj.get_variable('tomlf_dep')
 lib_deps += tomlf_dep


### PR DESCRIPTION
Should fix #48, because I was stupid.

Also pinning workflows for meson builds to ubuntu-22.04 for the moment.